### PR TITLE
Compatibility changes for graphql pagination

### DIFF
--- a/src/main/java/no/ssb/lds/api/persistence/flattened/DefaultFlattenedPersistence.java
+++ b/src/main/java/no/ssb/lds/api/persistence/flattened/DefaultFlattenedPersistence.java
@@ -27,6 +27,11 @@ public class DefaultFlattenedPersistence implements FlattenedPersistence {
     }
 
     @Override
+    public Persistence getPersistence() {
+        return persistence;
+    }
+
+    @Override
     public TransactionFactory transactionFactory() throws PersistenceException {
         return persistence.transactionFactory();
     }

--- a/src/main/java/no/ssb/lds/api/persistence/flattened/FlattenedDocument.java
+++ b/src/main/java/no/ssb/lds/api/persistence/flattened/FlattenedDocument.java
@@ -10,6 +10,8 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -88,14 +90,14 @@ public class FlattenedDocument {
         return allDocumentFragments.iterator();
     }
 
-    static FlattenedDocument decodeDocument(DocumentKey documentKey, Map<String, List<Fragment>> fragmentsByPath, int fragmentValueCapacityBytes) {
+    public static FlattenedDocument decodeDocument(DocumentKey documentKey, Map<String, ? extends Collection<Fragment>> fragmentsByPath, int fragmentValueCapacityBytes) {
         TreeMap<String, FlattenedDocumentLeafNode> leafNodesByPath = new TreeMap<>();
         CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
         CharBuffer out = CharBuffer.allocate(256);
         boolean deleted = false;
-        for (Map.Entry<String, List<Fragment>> entry : fragmentsByPath.entrySet()) {
+        for (Map.Entry<String, ? extends Collection<Fragment>> entry : fragmentsByPath.entrySet()) {
             String path = entry.getKey();
-            List<Fragment> fragments = entry.getValue();
+            List<Fragment> fragments = new ArrayList<>(entry.getValue());
             if (fragments.isEmpty()) {
                 throw new IllegalStateException("No fragments for path: " + path);
             }

--- a/src/main/java/no/ssb/lds/api/persistence/flattened/FlattenedPersistence.java
+++ b/src/main/java/no/ssb/lds/api/persistence/flattened/FlattenedPersistence.java
@@ -4,6 +4,7 @@ import no.ssb.lds.api.persistence.PersistenceDeletePolicy;
 import no.ssb.lds.api.persistence.PersistenceException;
 import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.TransactionFactory;
+import no.ssb.lds.api.persistence.streaming.Persistence;
 
 import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
@@ -17,6 +18,8 @@ import java.util.concurrent.CompletableFuture;
  * it should be used in favor of this layer to achieve predictable memory usage.
  */
 public interface FlattenedPersistence {
+
+    Persistence getPersistence();
 
     /**
      * Returns a factory that can be used to create new transactions.

--- a/src/main/java/no/ssb/lds/api/persistence/json/BufferedJsonPersistence.java
+++ b/src/main/java/no/ssb/lds/api/persistence/json/BufferedJsonPersistence.java
@@ -6,6 +6,7 @@ import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.TransactionFactory;
 import no.ssb.lds.api.persistence.flattened.FlattenedDocument;
 import no.ssb.lds.api.persistence.flattened.FlattenedPersistence;
+import no.ssb.lds.api.persistence.streaming.Persistence;
 import no.ssb.lds.api.specification.Specification;
 import org.json.JSONObject;
 
@@ -20,6 +21,11 @@ public class BufferedJsonPersistence implements JsonPersistence {
     public BufferedJsonPersistence(FlattenedPersistence flattenedPersistence, int fragmentValueCapacityBytes) {
         this.flattenedPersistence = flattenedPersistence;
         this.fragmentValueCapacityBytes = fragmentValueCapacityBytes;
+    }
+
+    @Override
+    public Persistence getPersistence() {
+        return flattenedPersistence.getPersistence();
     }
 
     @Override

--- a/src/main/java/no/ssb/lds/api/persistence/json/JsonPersistence.java
+++ b/src/main/java/no/ssb/lds/api/persistence/json/JsonPersistence.java
@@ -4,6 +4,7 @@ import no.ssb.lds.api.persistence.PersistenceDeletePolicy;
 import no.ssb.lds.api.persistence.PersistenceException;
 import no.ssb.lds.api.persistence.Transaction;
 import no.ssb.lds.api.persistence.TransactionFactory;
+import no.ssb.lds.api.persistence.streaming.Persistence;
 import no.ssb.lds.api.specification.Specification;
 
 import java.time.ZonedDateTime;
@@ -11,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface JsonPersistence {
 
+    Persistence getPersistence();
     /**
      * Returns a factory that can be used to create new transactions.
      *


### PR DESCRIPTION
@kimcs two small changes i needed to use RxJava in my wrapper.

This is needed until we update `JsonPersistence` with the changes we discussed yesterday.
```
public Persistence getPersistence() {
        return persistence;
}
```

Type migration from `List<Fragment>` to `? extends Collection<Fragment>` so that i can use RxJava groupBy operator to handle flattening in the wrapper.
```
public static FlattenedDocument decodeDocument(DocumentKey documentKey, Map<String, ? extends Collection<Fragment>> fragmentsByPath, int fragmentValueCapacityBytes) {
```

