### PR TITLE
Add a comparator that sorts the paths aware of indices

### DIFF
--- a/src/main/java/no/ssb/lds/api/persistence/flattened/FlattenedDocument.java
+++ b/src/main/java/no/ssb/lds/api/persistence/flattened/FlattenedDocument.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
-import java.util.regex.Pattern;
 
 import static java.util.Optional.ofNullable;
 
@@ -29,46 +28,7 @@ public class FlattenedDocument {
     /**
      * Paths with index need to be sorted lexicographically on the path but numerically on the indices.
      */
-    private static Comparator<String> INDEX_AWARE_PATH_COMPARATOR = new Comparator<>() {
-
-        Pattern pattern = Pattern.compile("(\\.|\\[|\\]\\.)");
-
-        boolean isDigit(CharSequence seq) {
-            for (int j = 0; j < seq.length(); j++) {
-                char charAt = seq.charAt(j);
-                if (!('0' <= charAt && charAt <= '9')) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public int compare(String path1, String path2) {
-            // Kinda optimized. Could be simpler but this code is called often.
-            String[] parts1 = pattern.split(path1);
-            String[] parts2 = pattern.split(path2);
-            if (parts1.length != parts2.length) {
-                return parts1.length < parts2.length ? -1 : +1;
-            } else {
-                int compare = 0;
-                for (int i = 0; i < parts1.length; i++) {
-                    if (isDigit(parts1[i]) && isDigit(parts2[i])) {
-                        compare = Integer.compareUnsigned(
-                                Integer.parseInt(parts1[i]),
-                                Integer.parseInt(parts2[i])
-                        );
-                    } else {
-                        compare = parts1[i].compareTo(parts2[i]);
-                    }
-                    if (compare != 0) {
-                        return compare;
-                    }
-                }
-                return compare;
-            }
-        }
-    };
+    private static Comparator<String> INDEX_AWARE_PATH_COMPARATOR = new PathComparator();
 
     private final DocumentKey key;
     private final Map<String, FlattenedDocumentLeafNode> leafNodesByPath;

--- a/src/main/java/no/ssb/lds/api/persistence/flattened/PathComparator.java
+++ b/src/main/java/no/ssb/lds/api/persistence/flattened/PathComparator.java
@@ -1,0 +1,45 @@
+package no.ssb.lds.api.persistence.flattened;
+
+import java.util.Comparator;
+import java.util.regex.Pattern;
+
+public class PathComparator implements Comparator<String> {
+
+    private static final Pattern SEPARATOR_PATTERN = Pattern.compile("(\\.|\\[|\\]\\.?)");
+
+    boolean isDigit(CharSequence seq) {
+        for (int j = 0; j < seq.length(); j++) {
+            char charAt = seq.charAt(j);
+            if (!('0' <= charAt && charAt <= '9')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int compare(String path1, String path2) {
+        // Kinda optimized. Could be simpler but this code is called often.
+        String[] parts1 = SEPARATOR_PATTERN.split(path1);
+        String[] parts2 = SEPARATOR_PATTERN.split(path2);
+        if (parts1.length != parts2.length) {
+            return parts1.length < parts2.length ? -1 : +1;
+        } else {
+            int compare = 0;
+            for (int i = 0; i < parts1.length; i++) {
+                if (isDigit(parts1[i]) && isDigit(parts2[i])) {
+                    compare = Integer.compareUnsigned(
+                            Integer.parseInt(parts1[i]),
+                            Integer.parseInt(parts2[i])
+                    );
+                } else {
+                    compare = parts1[i].compareTo(parts2[i]);
+                }
+                if (compare != 0) {
+                    return compare;
+                }
+            }
+            return compare;
+        }
+    }
+}

--- a/src/test/java/no/ssb/lds/api/persistence/flattened/PathComparatorTest.java
+++ b/src/test/java/no/ssb/lds/api/persistence/flattened/PathComparatorTest.java
@@ -1,0 +1,126 @@
+package no.ssb.lds.api.persistence.flattened;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PathComparatorTest {
+
+    private TreeMap<String, String> map;
+
+    @BeforeMethod
+    public void setUp() {
+        map = new TreeMap<>(new PathComparator());
+    }
+
+    @Test
+    public void testSortSimple() {
+
+        map.put("$.c.c", "");
+        map.put("$.c.b", "");
+        map.put("$.c.a", "");
+        map.put("$.b.c", "");
+        map.put("$.b.b", "");
+        map.put("$.b.a", "");
+        map.put("$.a.c", "");
+        map.put("$.a.b", "");
+        map.put("$.a.a", "");
+
+        assertThat(map.keySet()).containsExactly(
+                "$.a.a",
+                "$.a.b",
+                "$.a.c",
+                "$.b.a",
+                "$.b.b",
+                "$.b.c",
+                "$.c.a",
+                "$.c.b",
+                "$.c.c"
+        );
+
+    }
+
+    @Test
+    public void testSortIndices() {
+        map.put("$.a[10].c", "");
+        map.put("$.a[10].b", "");
+        map.put("$.a[10].a", "");
+        map.put("$.a[9].c", "");
+        map.put("$.a[9].b", "");
+        map.put("$.a[9].a", "");
+        map.put("$.a[0].c", "");
+        map.put("$.a[0].b", "");
+        map.put("$.a[0].a", "");
+
+        assertThat(map.keySet()).containsExactly(
+                "$.a[0].a",
+                "$.a[0].b",
+                "$.a[0].c",
+
+                "$.a[9].a",
+                "$.a[9].b",
+                "$.a[9].c",
+
+                "$.a[10].a",
+                "$.a[10].b",
+                "$.a[10].c"
+        );
+
+    }
+
+    @Test
+    public void testSortLeaf() {
+        map.put("$.a[9]", "");
+        map.put("$.a[10]", "");
+        map.put("$.a[0]", "");
+
+        assertThat(map.keySet()).containsExactly(
+                "$.a[0]",
+                "$.a[9]",
+                "$.a[10]"
+        );
+
+    }
+
+    @Test
+    public void testSortNested() {
+        map.put("$.a[10].b[9].b", "");
+        map.put("$.a[10].b[9].a", "");
+        map.put("$.a[10].b[10].b", "");
+        map.put("$.a[10].b[10].a", "");
+        map.put("$.a[9].b[10].b", "");
+        map.put("$.a[9].b[10].a", "");
+        map.put("$.a[9].b[9].b", "");
+        map.put("$.a[9].b[9].a", "");
+
+        assertThat(map.keySet()).containsExactly(
+                "$.a[9].b[9].a",
+                "$.a[9].b[9].b",
+                "$.a[9].b[10].a",
+                "$.a[9].b[10].b",
+                "$.a[10].b[9].a",
+                "$.a[10].b[9].b",
+                "$.a[10].b[10].a",
+                "$.a[10].b[10].b"
+        );
+
+    }
+
+    @Test
+    public void testSortNestedLeaf() {
+        map.put("$.a[10].b[10]", "");
+        map.put("$.a[10].b[9]", "");
+        map.put("$.a[9].b[10]", "");
+        map.put("$.a[9].b[9]", "");
+
+        assertThat(map.keySet()).containsExactly(
+                "$.a[9].b[9]",
+                "$.a[9].b[10]",
+                "$.a[10].b[9]",
+                "$.a[10].b[10]"
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://jira.ssb.no/browse/LDS-188

When paths contain more than 10 elements the lexicographical sort poses problems since `$.foo[10]` is less than `$.foo[9]`. 