### PR TITLE
Added optional reference from Specification to TypeDefinitionRegistry…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>12.0</version>
+            <version>15.0</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
             <artifactId>rxjava2-jdk9-interop</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java</artifactId>
+            <version>12.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module no.ssb.lds.persistence.api {
     requires com.github.akarnokd.rxjava2jdk9interop;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
+    requires graphql.java;
 
     exports no.ssb.lds.api.persistence;
     exports no.ssb.lds.api.persistence.flattened;

--- a/src/main/java/no/ssb/lds/api/persistence/Transaction.java
+++ b/src/main/java/no/ssb/lds/api/persistence/Transaction.java
@@ -28,4 +28,8 @@ public interface Transaction extends AutoCloseable {
             }
         }
     }
+
+    default <T> T getInstance(Class<T> clazz) {
+        return null;
+    }
 }

--- a/src/main/java/no/ssb/lds/api/persistence/reactivex/RxJsonPersistence.java
+++ b/src/main/java/no/ssb/lds/api/persistence/reactivex/RxJsonPersistence.java
@@ -168,4 +168,8 @@ public interface RxJsonPersistence {
      * @throws PersistenceException
      */
     void close() throws PersistenceException;
+
+    default <T> T getInstance(Class<T> clazz) {
+        return null;
+    }
 }

--- a/src/main/java/no/ssb/lds/api/specification/Specification.java
+++ b/src/main/java/no/ssb/lds/api/specification/Specification.java
@@ -1,5 +1,7 @@
 package no.ssb.lds.api.specification;
 
+import graphql.schema.idl.TypeDefinitionRegistry;
+
 import java.util.Set;
 
 public interface Specification {
@@ -7,4 +9,8 @@ public interface Specification {
     SpecificationElement getRootElement();
 
     Set<String> getManagedDomains();
+
+    default TypeDefinitionRegistry typeDefinitionRegistry() {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
Make the TypeDefinitionRegistry from GraphQL available in Specification. This is needed in order to convert write GRANDstack graphql compatible documents in the neo4j persistence provider.